### PR TITLE
Add seminars page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,51 +3,51 @@ help:
 
 # start (or restart) the services
 server: .FORCE
-	docker-compose down --remove-orphans || true;
-	docker-compose up
+	docker compose down --remove-orphans || true;
+	docker compose up
 
 # start (or restart) the services in detached mode
 server-detached: .FORCE
-	docker-compose down || true;
-	docker-compose up -d
+	docker compose down || true;
+	docker compose up -d
 
 # build or rebuild the services WITHOUT cache
 build: .FORCE
 	chmod 777 Gemfile.lock
-	docker-compose stop || true; docker-compose rm || true;
+	docker compose stop || true; docker compose rm || true;
 	docker build --no-cache -t fastai/fastpages-jekyll -f _action_files/fastpages-jekyll.Dockerfile .
-	docker-compose build --force-rm --no-cache
+	docker compose build --force-rm --no-cache
 
 # rebuild the services WITH cache
 quick-build: .FORCE
-	docker-compose stop || true;
+	docker compose stop || true;
 	docker build -t fastai/fastpages-jekyll -f _action_files/fastpages-jekyll.Dockerfile .
-	docker-compose build 
+	docker compose build 
 
 # convert word & nb without Jekyll services
 convert: .FORCE
-	docker-compose up converter
+	docker compose up converter
 
 # stop all containers
 stop: .FORCE
-	docker-compose stop
+	docker compose stop
 	docker ps | grep fastpages | awk '{print $1}' | xargs docker stop
 
 # remove all containers
 remove: .FORCE
-	docker-compose stop  || true; docker-compose rm || true;
+	docker compose stop  || true; docker compose rm || true;
 
 # get shell inside the notebook converter service (Must already be running)
 bash-nb: .FORCE
-	docker-compose exec watcher /bin/bash
+	docker compose exec watcher /bin/bash
 
 # get shell inside jekyll service (Must already be running)
 bash-jekyll: .FORCE
-	docker-compose exec jekyll /bin/bash
+	docker compose exec jekyll /bin/bash
 
 # restart just the Jekyll server
 restart-jekyll: .FORCE
-	docker-compose restart jekyll
+	docker compose restart jekyll
 
 .FORCE:
 	chmod -R u+rw .

--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,9 @@ github_repo: "sciml-leeds"
 # Note: leave out the trailing / from this value. 
 url: "https://sciml-leeds.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 
+# we should replace this when we get a committee email account
+contact_email: l.c.denby@leeds.ac.uk
+
 ###########################################################
 #########  Special Instructions for baseurl ###############
 #

--- a/_pages/seminars.md
+++ b/_pages/seminars.md
@@ -1,0 +1,48 @@
+---
+layout: page
+title: Seminars
+permalink: /seminars/
+data:
+  - title: Physics-informed Machine Learning for Trustworthy Climate Emulators
+    datetime: 2023-02-10T14:00:00Z
+    speaker: Björn Lütjens (MIT)
+  - title: Explainable AI for identifying regional climate change patterns
+    datetime: 2023-01-13T14:00:00Z
+    speaker: Zack Labe (Princeton)
+    media:
+      youtube: https://www.youtube.com/watch?v=ZIZbu1o33xQ&t=4s
+  - title: Extending the capabilities of data-driven reduced-order models to make predictions for unseen scenarios
+    datetime: 2020-11-18T11:00:00Z
+    speaker: Claire Heaney (Imperial College)
+---
+
+Below is an overview seminars organised by the SciML community. We aim to put
+recordings of each seminar online within a week of the seminar taking place.
+
+[Please get in touch <i class="fa fa-envelope"></i>](mailto://{{site.contact_email}}) if you'd like to come to
+talk to us, we're a very diverse group in terms of applications in scientific
+machine learning and would <i class="fa fa-heart"></i> to hear about your work!
+
+<table>
+<tr>
+<th>Title</th>
+<th>Speaker</th>
+<th>Date</th>
+<th>Media</th>
+</tr>
+
+{% for talk in page.data %}
+<tr>
+<td>{{talk.title}}</td>
+<td>{{talk.speaker}}</td>
+<td>{{talk.datetime | date: "%d/%m/%Y %H:%M"}}</td>
+<td>
+{% if talk.media.youtube %}
+<a href="{{talk.media.youtube}}">recording</a>
+{% endif %}
+</td>
+</tr>
+{% endfor %}
+
+</table>
+

--- a/_sass/minima/fastpages-styles.scss
+++ b/_sass/minima/fastpages-styles.scss
@@ -29,7 +29,7 @@ img.emoji{
 
 // make non-headings slightly lighter
 .post-content p, .post-content li {
-   font-size: 20px;
+   font-size: 16px;
    color: #515151;
 }
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,8 @@ pull-request to add yourself to this website:
 
 We meet the first Friday of every month at 11am UK/local time in our home in LIDA (Leeds
 Institute for Data Analytics), Worsley Building, 11th Floor, room 11.87.
-([.ics-file download](assets/SciML_community_monthly_coffee-chat.ics) to add the event to your calendar)
+([.ics-file download](assets/SciML_community_monthly_coffee-chat.ics) to add
+the event to your calendar). We also organise [seminars](/seminars).
 
 ## People
 


### PR DESCRIPTION
I've added a "Seminars" page with a table where we can list the seminars we organise and put links to the recordings. It should be easy to add more seminars by editing the top of the page.