### PR TITLE
Revert "add recording for Bjorn's talk"

### DIFF
--- a/_pages/seminars.md
+++ b/_pages/seminars.md
@@ -6,8 +6,6 @@ data:
   - title: Sea ice detection from concurrent visible and SAR imagery using a convolutional neural network
     datetime: 2023-02-24T11:00:00Z
     speaker: Martin Rogers, British Antarctic Survey
-    media:
-      youtube: https://www.youtube.com/watch?v=826wF2DNTms
   - title: Physics-informed Machine Learning for Trustworthy Climate Emulators
     datetime: 2023-02-10T14:00:00Z
     speaker: Björn Lütjens (MIT)


### PR DESCRIPTION
Reverts sciml-leeds/sciml-leeds.github.io#56

think there's been confusion - bjorn's link already added and this link is put under the sea ice row