### PR TITLE
Fix base template rename

### DIFF
--- a/_layouts/categories.html
+++ b/_layouts/categories.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: base
 ---
 
 <div class="home">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: base
 ---
 
 <div class="home">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: base
 ---
 <article class="post h-entry" itemscope itemtype="http://schema.org/BlogPosting">
 


### PR DESCRIPTION
Fix rendering issue due to the fact that `minima` theme in jekyll recently renamed the default template from `default` to `base` (https://github.com/jekyll/minima/pull/690) which broke all our pages so that they weren't rendering correctly.