### PR TITLE
Pin ruby ffi version to fix deploy issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,3 +41,5 @@ gem "wdm", "~> 0.1.1", :install_if => Gem.win_platform?
 
 gem "faraday", "< 1.0"
 
+# https://github.com/ffi/ffi/issues/1103
+gem "ffi", "< 1.17.0"


### PR DESCRIPTION
It appears that the jekyll install fails because a newer version of the `ffi` depedency requires a different upstream package version. This commit applies the fix suggested on https://github.com/ffi/ffi/issues/1103 which is to pin the `ffi` version. This worked on sciml-dmi repo (https://github.com/dmidk/sciml-dmi/commit/fa874a0ebf97822fbde2fda80ca960ff06c31e49) so I thought I would make a PR for that fix here too since I noticed you had the same issue :)

https://github.com/sciml-leeds/sciml-leeds.github.io/actions/runs/9861747497/job/27230857702